### PR TITLE
chore: rename project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # binaries
-/awswitch
-/awswitch-*
+/ax
+/ax-*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,6 @@
 builds:
   - id: linux-build
-    binary: awswitch
+    binary: ax
     goos:
       - linux
     goarch:
@@ -14,10 +14,10 @@ builds:
       -w
       -s
       -extldflags '-static'
-      -X github.com/ArcadiaPower/awswitch/main.version={{.Version}}
+      -X github.com/ArcadiaPower/axolotl/main.Version={{.Version}}
 
   - id: darwin-build
-    binary: awswitch
+    binary: ax
     goos:
       - darwin
     goarch:
@@ -37,7 +37,7 @@ archives:
       - darwin-build
 
 brews:
-  - name: awswitch
+  - name: ax
 
     ids:
       - darwin-archives
@@ -51,9 +51,9 @@ brews:
 
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
 
-    caveats: "To install shell completion add the following line to your #{shell_profile}:\n\tBASH:\n\teval \"$(awswitch --completion-script-bash)\"\n\tZSH:\n\teval \"$(awswitch --completion-script-zsh)\"\n\nRestart your terminal for the settings to take effect."
+    caveats: "To install shell completion add the following line to your #{shell_profile}:\n\tBASH:\n\teval \"$(ax --completion-script-bash)\"\n\tZSH:\n\teval \"$(ax --completion-script-zsh)\"\n\nRestart your terminal for the settings to take effect."
 
-    homepage: "https://github.com/ArcadiaPower/awswitch/"
+    homepage: "https://github.com/ArcadiaPower/axolotl/"
 
     description: "A helper utility for switching AWS profiles in subshells."
 
@@ -64,4 +64,4 @@ brews:
       - name: gimme-aws-creds
 
     test: |
-      system "#{bin}/awswitch --version"
+      system "#{bin}/ax --version"

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ SRC=$(shell find . -name '*.go') go.mod
 INSTALL_DIR ?= ~/.bin
 .PHONY: install
 
-awswitch: $(SRC)
+ax: $(SRC)
 	go build -ldflags="-X main.Version=$(VERSION)" -o $@ .
 
-install: awswitch
+install: ax
 	mkdir -p $(INSTALL_DIR)
-	rm -f $(INSTALL_DIR)/awswitch
-	cp -a ./awswitch $(INSTALL_DIR)/awswitch
+	rm -f $(INSTALL_DIR)/ax
+	cp -a ./ax $(INSTALL_DIR)/ax

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# awswitch
+# axolotl
 
-![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/ArcadiaPower/awswitch?style=for-the-badge)![GitHub release (latest by date)](https://img.shields.io/github/v/release/ArcadiaPower/awswitch?style=for-the-badge)![GitHub](https://img.shields.io/github/license/ArcadiaPower/awswitch?style=for-the-badge)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/ArcadiaPower/axolotl?style=for-the-badge)![GitHub release (latest by date)](https://img.shields.io/github/v/release/ArcadiaPower/axolotl?style=for-the-badge)![GitHub](https://img.shields.io/github/license/ArcadiaPower/axolotl?style=for-the-badge)
 
-awswitch is an opinionated CLI that minimally emulates the behavior of the `aws-vault exec` command to run ad-hoc commands or switch to a subshell of a specific AWS profiles on the fly.
+axolotl (`ax`) is an opinionated CLI that minimally emulates the behavior of the `aws-vault exec` command to run ad-hoc commands or switch to a subshell of a specific AWS profiles on the fly.
 
-Additionally, credentials are obtained automatically using `gimme-aws-creds` to make a simple one command workflow for switching AWS profiles and credentials. This behavior can be disabled by running `awswitch --no-verify` and re-enabled by `awswitch --verify`.
+Additionally, credentials are obtained automatically using `gimme-aws-creds` to make a simple one command workflow for switching AWS profiles and credentials. This behavior can be disabled by running `ax --no-verify` and re-enabled by `ax --verify`.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ This is a Go CLI and as such can be installed the standard Go way if you have a 
 
 Install with `go install`
 ```bash
-go install github.com/ArcadiaPower/awswitch@latest
+go install github.com/ArcadiaPower/axolotl@latest
 ```
 
 __OR__
@@ -24,41 +24,41 @@ __OR__
 Install with homebrew
 ```bash
 brew tap ArcadiaPower/tap
-brew install awswitch
+brew install ArcadiaPower/tap/axolotl
 ```
 
 Note: Installing with homebrew has the added benefit of automatically installing `gimme-aws-creds` as a dependency if it wasn't already installed.
 
 ## Configuration
 
-The configuration file is created automatically at `$HOME/.config/awswitch/config.yaml` if it doesn't already exist. 
+The configuration file is created automatically at `$HOME/.config/ax/config.yaml` if it doesn't already exist. 
 - autogimmeawscreds - This enables automatic credential verification and acquisition with `gimme-aws-creds`, the default is true.
 
 ## Usage
 
 To switch to a named profile and the default AWS Region of `us-east-1`:
 ```bash
-awswitch --profile example-staging
+ax --profile example-staging
 ```
 
 To switch to a named profile and a custom AWS Region:
 ```bash
-awswitch --profile example-staging --region us-west-2
+ax --profile example-staging --region us-west-2
 ```
 
 Same as the last example, but use short flags:
 ```bash
-awswitch -p example-staging -r us-west-2
+ax -p example-staging -r us-west-2
 ```
 
 Execute a single command using a named profile:
 ```bash
-awswitch -p example-staging -- aws sts get-caller-identity
+ax -p example-staging -- aws sts get-caller-identity
 ```
 
 ### Profile Completion
 
-If you run `awswitch` without passing any arguments the tool provides autocomplete and tabcomplete functionality based on the profile names in your local `~/.aws/credentials` file or the file specified by the `$AWS_SHARED_CREDENTIALS_FILE` environment variable if set.
+If you run `ax` without passing any arguments the tool provides autocomplete and tabcomplete functionality based on the profile names in your local `~/.aws/credentials` file or the file specified by the `$AWS_SHARED_CREDENTIALS_FILE` environment variable if set.
 
 ## Credit and Why Yet Another Tool
 
@@ -70,7 +70,7 @@ I wanted the simplicity of the `aws-vault exec` command with the requirement for
 
 ## License
 
-awswitch is released under the [MIT License](https://opensource.org/licenses/MIT)
+ax is released under the [MIT License](https://opensource.org/licenses/MIT)
 
 [aws-vault]: https://github.com/99designs/aws-vault
 [saml2aws]: https://github.com/Versent/saml2aws

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # axolotl
 
+![_Axolotl_](https://i.imgur.com/wcOZg4d.jpg)
+
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/ArcadiaPower/axolotl?style=for-the-badge)![GitHub release (latest by date)](https://img.shields.io/github/v/release/ArcadiaPower/axolotl?style=for-the-badge)![GitHub](https://img.shields.io/github/license/ArcadiaPower/axolotl?style=for-the-badge)
 
 axolotl (`ax`) is an opinionated CLI that minimally emulates the behavior of the `aws-vault exec` command to run ad-hoc commands or switch to a subshell of a specific AWS profiles on the fly.

--- a/cli/common.go
+++ b/cli/common.go
@@ -9,20 +9,20 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ArcadiaPower/awswitch/sdk/vault"
+	"github.com/ArcadiaPower/axolotl/sdk/vault"
 	"github.com/alecthomas/kingpin"
 	"github.com/c-bata/go-prompt"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
 )
 
-type Awswitch struct {
+type Axolotl struct {
 	Debug              bool
 	autoGimmeAwsCreds  bool
 	awsCredentialsFile *vault.CredentialsFile
 }
 
-func (a *Awswitch) AwsCredentialsFile() (*vault.CredentialsFile, error) {
+func (a *Axolotl) AwsCredentialsFile() (*vault.CredentialsFile, error) {
 	if a.awsCredentialsFile == nil {
 		var err error
 		a.awsCredentialsFile, err = vault.LoadCredentialsFromEnv()
@@ -34,7 +34,7 @@ func (a *Awswitch) AwsCredentialsFile() (*vault.CredentialsFile, error) {
 	return a.awsCredentialsFile, nil
 }
 
-func (a *Awswitch) MustGetProfileNames() []string {
+func (a *Axolotl) MustGetProfileNames() []string {
 	creds, err := a.AwsCredentialsFile()
 	if err != nil {
 		log.Fatalf("Error loading AWS credentials: %s", err.Error())
@@ -125,7 +125,7 @@ func AuthGimmeAwsCreds() error {
 }
 
 // ConfigureGlobals sets up the global flags and returns the global config
-func ConfigureGlobals(app *kingpin.Application) *Awswitch {
+func ConfigureGlobals(app *kingpin.Application) *Axolotl {
 	// Load config from file
 	if err := viper.ReadInConfig(); err != nil {
 		log.Printf("fatal error config file: %v", err)
@@ -133,7 +133,7 @@ func ConfigureGlobals(app *kingpin.Application) *Awswitch {
 
 	viper.GetBool("autoGimmeAwsCreds")
 
-	a := &Awswitch{
+	a := &Axolotl{
 		autoGimmeAwsCreds: viper.GetBool("autoGimmeAwsCreds"),
 	}
 
@@ -156,7 +156,7 @@ func ConfigureGlobals(app *kingpin.Application) *Awswitch {
 			log.SetOutput(io.Discard)
 		}
 
-		log.Printf("awswitch %s", app.Model().Version)
+		log.Printf("Axolotl %s", app.Model().Version)
 
 		if noVerify {
 			viper.Set("autoGimmeAwsCreds", false)
@@ -224,7 +224,7 @@ func restoreTermState() {
 }
 
 // profileCompleter returns a list of profile names
-func (a *Awswitch) profileCompleter() func(d prompt.Document) []prompt.Suggest {
+func (a *Axolotl) profileCompleter() func(d prompt.Document) []prompt.Suggest {
 	return func(d prompt.Document) []prompt.Suggest {
 		s := []prompt.Suggest{}
 		for _, p := range a.MustGetProfileNames() {

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -18,7 +18,7 @@ type ExecCommandInput struct {
 	Verify      bool
 }
 
-func ConfigureExecCommand(app *kingpin.Application, a *Awswitch) {
+func ConfigureExecCommand(app *kingpin.Application, a *Axolotl) {
 	input := ExecCommandInput{
 		Verify: a.autoGimmeAwsCreds,
 	}
@@ -42,8 +42,8 @@ func ConfigureExecCommand(app *kingpin.Application, a *Awswitch) {
 		StringsVar(&input.Args)
 
 	app.Action(func(c *kingpin.ParseContext) error {
-		if os.Getenv("AWS_SWITCH") != "" {
-			return fmt.Errorf("awswitch sessions should be nested with care, unset AWS_SWITCH to force")
+		if os.Getenv("AWS_AXOLOTL") != "" {
+			return fmt.Errorf("ax sessions should be nested with care, unset AWS_AXOLOTL to force")
 		}
 
 		if input.ProfileName == "" {
@@ -62,7 +62,7 @@ func ExecCommand(input ExecCommandInput) error {
 	env.Set("AWS_DEFAULT_PROFILE", input.ProfileName)
 	env.Set("AWS_PROFILE", input.ProfileName)
 	env.Set("AWS_REGION", input.Region)
-	env.Set("AWS_SWITCH", "42")
+	env.Set("AWS_AXOLOTL", "42")
 
 	if err := AuthVerify(input.Verify, input.ProfileName); err != nil {
 		return err

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -3,13 +3,13 @@ package cli_test
 import (
 	"testing"
 
-	"github.com/ArcadiaPower/awswitch/cli"
+	"github.com/ArcadiaPower/axolotl/cli"
 	"github.com/alecthomas/kingpin"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExecCommand(t *testing.T) {
-	app := kingpin.New("awswitch", "")
+	app := kingpin.New("ax", "")
 	a := cli.ConfigureGlobals(app)
 	cli.ConfigureExecCommand(app, a)
 	_, err := app.Parse([]string{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ArcadiaPower/awswitch
+module github.com/ArcadiaPower/axolotl
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -6,20 +6,20 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ArcadiaPower/awswitch/cli"
+	"github.com/ArcadiaPower/axolotl/cli"
 	"github.com/spf13/viper"
 
 	"github.com/alecthomas/kingpin"
 )
 
 // Version is provided at compile time
-var Version string
+var Version = "devel"
 
 func init() {
 	// initialize viper config
 	configName := "config"
 	configType := "yaml"
-	configPath := os.ExpandEnv("${HOME}/.config/awswitch")
+	configPath := os.ExpandEnv("${HOME}/.config/ax")
 
 	viper.AddConfigPath(configPath)
 	viper.SetConfigName(configName)
@@ -43,7 +43,7 @@ func init() {
 }
 
 func main() {
-	app := kingpin.New("awswitch", "A helper utility for switching AWS profiles in subshells.")
+	app := kingpin.New("ax", "A helper utility for switching AWS profiles in subshells.")
 	app.Version(Version)
 
 	a := cli.ConfigureGlobals(app)


### PR DESCRIPTION
Renames the project from awswitch to axolotl. We were made aware of some unfortunate Google search auto-correction on the original name so no better time to rename and go with the shorter `ax` command.