### PR TITLE
feat: set AWS_DEFAULT_REGION

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -61,6 +61,7 @@ func ExecCommand(input ExecCommandInput) error {
 	env := environ(os.Environ())
 	env.Set("AWS_DEFAULT_PROFILE", input.ProfileName)
 	env.Set("AWS_PROFILE", input.ProfileName)
+	env.Set("AWS_DEFAULT_REGION", input.Region)
 	env.Set("AWS_REGION", input.Region)
 	env.Set("AWS_AXOLOTL", "42")
 


### PR DESCRIPTION
This updates the `ax` utility to set the `AWS_DEFAULT_REGION` envvar to the region specified by the user or the default value of us-east-1