### PR TITLE
feat: allow default region to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Note: Installing with homebrew has the added benefit of automatically installing
 
 The configuration file is created automatically at `$HOME/.config/ax/config.yaml` if it doesn't already exist. 
 - autogimmeawscreds - This enables automatic credential verification and acquisition with `gimme-aws-creds`, the default is true.
+- defaultregion - This sets the default AWS region that will be used, the default is `us-east-1`.
 
 ## Usage
 
@@ -43,7 +44,7 @@ To switch to a named profile and the default AWS Region of `us-east-1`:
 ax --profile example-staging
 ```
 
-To switch to a named profile and a custom AWS Region:
+To switch to a named profile and a specific AWS Region:
 ```bash
 ax --profile example-staging --region us-west-2
 ```
@@ -55,6 +56,13 @@ ax -p example-staging -r us-west-2
 
 Execute a single command using a named profile:
 ```bash
+ax -p example-staging -- aws sts get-caller-identity
+```
+
+Change the default region to `us-west-2` and execute a single command using a named profile without having to specify the region:
+```bash
+ax --default-region us-west-2
+
 ax -p example-staging -- aws sts get-caller-identity
 ```
 

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -16,6 +16,7 @@ type ExecCommandInput struct {
 	Command     string
 	Args        []string
 	Verify      bool
+	AutoRegion  bool
 }
 
 func ConfigureExecCommand(app *kingpin.Application, a *Axolotl) {
@@ -29,7 +30,7 @@ func ConfigureExecCommand(app *kingpin.Application, a *Axolotl) {
 		StringVar(&input.ProfileName)
 
 	app.Flag("region", "The AWS region to execute to").
-		Default("us-east-1").
+		Default(a.defaultRegion).
 		Short('r').
 		HintOptions("us-east-1", "us-west-2").
 		StringVar(&input.Region)

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func init() {
 
 	// set default values
 	viper.SetDefault("autoGimmeAwsCreds", true)
+	viper.SetDefault("defaultRegion", "us-east-1")
 
 	configFile := filepath.Join(configPath, fmt.Sprintf("%s.%s", configName, configType))
 


### PR DESCRIPTION
This PR adds a configuration property to `ax` allowing users to specify a preferred default AWS region when spawning new shells.

The default setting remains us-east-1 and this should help in cases where someone commonly works in a different region and wants to default to that region instead of having to always pass the `-r` flag.