### PR TITLE
feat: support for multiple gimme-aws-creds profiles

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -84,7 +84,7 @@ func (a *Axolotl) MustGetGACProfileNames() []string {
 
 // AuthVerify checks if the user is authenticated and if not authenticates
 // with gimme-aws-creds
-func AuthVerify(enabled bool, awsProfileName, gacProfile string) error {
+func AuthVerify(enabled bool, profile Profile) error {
 	if !enabled {
 		return nil
 	}
@@ -108,7 +108,7 @@ func AuthVerify(enabled bool, awsProfileName, gacProfile string) error {
 			os.Setenv(strings.Split(e, "=")[0], strings.Split(e, "=")[1])
 		}
 	}
-	os.Setenv("AWS_PROFILE", awsProfileName)
+	os.Setenv("AWS_PROFILE", profile.AWS)
 
 	// Check if we are authenticated by running aws sts get-caller-identity
 	// If we are not authenticated, we will get an error
@@ -128,7 +128,7 @@ func AuthVerify(enabled bool, awsProfileName, gacProfile string) error {
 	}
 
 	// If we are not authenticated, we will run gimme-aws-creds
-	return AuthGimmeAwsCreds(gacProfile)
+	return AuthGimmeAwsCreds(profile.GimmeAWSCreds)
 }
 
 // AuthGimmeAwsCreds authenticates with gimme-aws-creds


### PR DESCRIPTION
This PR updates `ax` to support situations where a user has multiple profiles configured for `gimme-aws-creds`. 

If a user only has a single profile configured for `gimme-aws-creds` they won't notice any changes since the tool automatically sets the profile in the event of only one option.

If there are multiple `gimme-aws-creds` profiles configured then the user gets prompted to select which one to use for a given AWS profile. Mapping of AWS profiles -> gimme-aws-creds profiles is persisted in the `ax` config file at `$HOME/.config/ax/config.yaml` automatically over time. Example of what the config looks like:
```yaml
# ~/.config/ax/config.yaml
autogimmeawscreds: true
defaultregion: us-east-1
profiles:
    contoso-admin: DEFAULT
    waystar-dev: waystar
    acme-viewer: acme
```

This means users can manually configure profile mappings ahead of time in bulk if they know the names of their AWS profiles and gimme-aws-creds profiles in advance.