### PR TITLE
feat: raise error and prevent spawning subshell without credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # axolotl
 
-![_Axolotl_](https://i.imgur.com/wcOZg4d.jpg)
+![_Axolotl_](https://user-images.githubusercontent.com/6409227/217604228-17b830df-1069-4e4e-b8fc-8b164de32233.png)
 
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/ArcadiaPower/axolotl?style=for-the-badge)![GitHub release (latest by date)](https://img.shields.io/github/v/release/ArcadiaPower/axolotl?style=for-the-badge)![GitHub](https://img.shields.io/github/license/ArcadiaPower/axolotl?style=for-the-badge)
 

--- a/cli/common.go
+++ b/cli/common.go
@@ -89,15 +89,24 @@ func AuthVerify(enabled bool, profile Profile) error {
 		return nil
 	}
 
-	// TODO: This is really ugly and adds a performance hit for the aws cli call
-	// but there isn't a better way to verify credentials UNLESS this PR is merged
-	// to gimme-aws-creds: https://github.com/Nike-Inc/gimme-aws-creds/pull/300
-
 	// Check if aws cli is installed
 	if _, err := exec.LookPath("aws"); err != nil {
 		return fmt.Errorf("unable to locate `aws` in PATH, please install it: %w", err)
 	}
 
+	if canAuth(profile) {
+		return nil
+	}
+
+	// If we are not authenticated, we will run gimme-aws-creds
+	return AuthGimmeAwsCreds(profile)
+}
+
+// canAuth checks if the user is authenticated with the given profile
+// TODO: This is really ugly and adds a performance hit for the aws cli call
+// but there isn't a better way to verify credentials UNLESS this PR is merged
+// to gimme-aws-creds: https://github.com/Nike-Inc/gimme-aws-creds/pull/300
+func canAuth(profile Profile) bool {
 	// Temporarily set AWS_PROFILE to the profile we want to check
 	// so that we can use the aws cli to check if we are authenticated
 	// with the profile
@@ -114,25 +123,23 @@ func AuthVerify(enabled bool, profile Profile) error {
 	// If we are not authenticated, we will get an error
 	// If we are authenticated, we will get a json response
 	// We will ignore the json response
+	// restore environment
 	cmd := exec.Command("aws", "sts", "get-caller-identity")
 	err := cmd.Run()
 
-	// restore environment
 	os.Clearenv()
 	for _, e := range origEnv {
 		os.Setenv(strings.Split(e, "=")[0], strings.Split(e, "=")[1])
 	}
 
 	if err == nil {
-		return nil
+		return true
 	}
-
-	// If we are not authenticated, we will run gimme-aws-creds
-	return AuthGimmeAwsCreds(profile.GimmeAWSCreds)
+	return false
 }
 
 // AuthGimmeAwsCreds authenticates with gimme-aws-creds
-func AuthGimmeAwsCreds(gacProfile string) error {
+func AuthGimmeAwsCreds(profile Profile) error {
 	// Check if gimme-aws-creds is installed
 	if _, err := exec.LookPath("gimme-aws-creds"); err != nil {
 		return fmt.Errorf("unable to locate `gimme-aws-creds` in PATH, please install it: %w\n\n\thttps://github.com/Nike-Inc/gimme-aws-creds#installation", err)
@@ -144,7 +151,7 @@ func AuthGimmeAwsCreds(gacProfile string) error {
 	}
 
 	// execute gimme-aws-creds
-	cmd := exec.Command("gimme-aws-creds", "--profile", gacProfile)
+	cmd := exec.Command("gimme-aws-creds", "--profile", profile.GimmeAWSCreds)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
@@ -152,7 +159,19 @@ func AuthGimmeAwsCreds(gacProfile string) error {
 		return fmt.Errorf("unable to execute `gimme-aws-creds`: %w", err)
 	}
 
-	return nil
+	// Verify we are authenticated to AWS now that we have run gimme-aws-creds
+	if canAuth(profile) {
+		return nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "~"
+	}
+
+	// TODO: It might be worthwhile to try and handle this case better if enough
+	// people run into it. For now, let's just return an error.
+	return fmt.Errorf("unable to authenticate to AWS with profile %s. Check %s/.aws/credentials to ensure this profile exists", profile.AWS, home)
 }
 
 // ConfigureGlobals sets up the global flags and returns the global config

--- a/cli/common.go
+++ b/cli/common.go
@@ -123,10 +123,10 @@ func canAuth(profile Profile) bool {
 	// If we are not authenticated, we will get an error
 	// If we are authenticated, we will get a json response
 	// We will ignore the json response
-	// restore environment
 	cmd := exec.Command("aws", "sts", "get-caller-identity")
 	err := cmd.Run()
 
+	// restore environment
 	os.Clearenv()
 	for _, e := range origEnv {
 		os.Setenv(strings.Split(e, "=")[0], strings.Split(e, "=")[1])

--- a/main.go
+++ b/main.go
@@ -50,5 +50,6 @@ func main() {
 	a := cli.ConfigureGlobals(app)
 	cli.ConfigureExecCommand(app, a)
 
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	_, err := app.Parse(os.Args[1:])
+	kingpin.FatalIfError(err, "")
 }


### PR DESCRIPTION
This PR updates `ax` to verify the user provided profile name by executing the `aws sts get-caller-identity` command a second time after re-hydrating credentials with `gimme-aws-creds`

Prior to this change if a user ran `ax -p not-a-real-profile` we would re-hydrate credentials and then spawn a subshell setting `$AWS_PROFILE` to `not-a-real-profile`. Assuming this profile name is invalid this leaves the user in a confusing state where it appears that `ax` ran successfully, but the subshell lacks valid AWS credentials.

Now when this occurs we'll detect it and surface an error to the user to indicate something went wrong:
```bash
❯ ./ax -p not-a-real-profile
Using password from keyring for john.doe@example.com
Multi-factor Authentication required.
Okta Verify App: SmartPhone_IPhone: iPhone selected
Okta Verify push sent...
Authentication Success!
Saving arn:aws:iam::111111111111:role/devops as waystar-devops
Written profile waystar-devops to /Users/johndoe/.aws/credentials
Saving arn:aws:iam::111111111111:role/readonly as waystar-readonly
Written profile waystar-readonly to /Users/johndoe/.aws/credentials
Saving arn:aws:iam::222222222222:role/devops as acme-devops
Written profile acme-devops to /Users/johndoe/.aws/credentials
Saving arn:aws:iam::222222222222:role/readonly as acme-readonly
Written profile acme-readonly to /Users/johndoe/.aws/credentials
ax: error: unable to authenticate to AWS with profile not-a-real-profile. Check /Users/johndoe/.aws/credentials to ensure this profile exists
```