### PR TITLE
feat(SRE-229): add support for OIE browser authentication

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -172,7 +172,6 @@ func ConfigureGlobals(app *kingpin.Application) *Axolotl {
 
 	viper.GetBool("autoGimmeAwsCreds")
 	viper.GetString("defaultRegion")
-	viper.GetBool("oie")
 	viper.GetStringMapString("profiles")
 
 	a := &Axolotl{

--- a/cli/gimme_aws_creds.go
+++ b/cli/gimme_aws_creds.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/pkg/browser"
+)
+
+const (
+	gimmeAWSCredsURL    = "https://github.com/Nike-Inc/gimme-aws-creds#installation"
+	gimmeAWSCredsConfig = ".okta_aws_login_config"
+)
+
+func checkGimmeAwsCredsInstallation() error {
+	if _, err := exec.LookPath("gimme-aws-creds"); err != nil {
+		return fmt.Errorf("unable to locate `gimme-aws-creds` in PATH, please install it: %w\n\n\t%s", err, gimmeAWSCredsURL)
+	}
+	return nil
+}
+
+func verifyConfigFileExists() error {
+	configFilePath := filepath.Join(os.Getenv("HOME"), gimmeAWSCredsConfig)
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		return fmt.Errorf("unable to locate %s in ${HOME}, please create it: %w\n\n\t%s", gimmeAWSCredsConfig, err, gimmeAWSCredsURL)
+	}
+	return nil
+}
+
+func executeGimmeAwsCreds(profile Profile) error {
+	cmd := exec.Command("gimme-aws-creds", "--profile", profile.GimmeAWSCreds)
+	stdoutPipe, _ := cmd.StdoutPipe()
+	stderrPipe, _ := cmd.StderrPipe()
+	cmd.Stdin = os.Stdin
+
+	err := cmd.Start()
+	if err != nil {
+		return fmt.Errorf("unable to start `gimme-aws-creds`: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	urlRegex := regexp.MustCompile(`https://[a-zA-Z0-9.-/=?_]+`)
+	wg.Add(2) // Two goroutines for stdout and stderr
+
+	readPipe := func(pipeName string, pipe io.Reader) {
+		defer wg.Done()
+
+		scanner := bufio.NewScanner(pipe)
+		for scanner.Scan() {
+			line := scanner.Text()
+			fmt.Println(line) // Echo the line back to stdout
+
+			domains := []string{"oktapreview.com", "okta.com"}
+
+			var hasOktaURL bool
+			for _, domain := range domains {
+				if strings.Contains(line, domain) {
+					hasOktaURL = true
+					break
+				}
+			}
+
+			if hasOktaURL {
+				urlMatch := urlRegex.FindString(line)
+				if urlMatch != "" {
+					if err := browser.OpenURL(urlMatch); err != nil {
+						fmt.Printf("Failed to open URL: %s\n", err)
+					}
+				}
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			fmt.Printf("Error reading %s: %s\n", pipeName, err)
+		}
+	}
+
+	go readPipe("stdout", stdoutPipe)
+	go readPipe("stderr", stderrPipe)
+
+	wg.Wait()
+
+	// Wait for command to finish
+	err = cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("error executing `gimme-aws-creds`: %w", err)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/term v1.2.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
 github.com/pelletier/go-toml/v2 v2.0.5/go.mod h1:OMHamSCAODeSsVrwwvcJOaoN0LIUIaFVNZzmWyNfXas=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pkg/term v1.2.0-beta.2 h1:L3y/h2jkuBVFdWiJvNfYfKmzcCnILw7mJWm2JQuMppw=
@@ -333,6 +335,7 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This change adds support to automatically detect when the login challenge from `gimme-aws-creds` is for an Okta Identity Engine (OIE) tenant. These login challenges utilize a "click this URL to sign in" flow. The change from this PR detects the callback URL presented to the terminal's stdout and automatically opens the URL in the user's default browser to make this login process a bit more automatic.

I also took the opportunity to break the `AuthGimmeAwsCreds()` function up into smaller functions with less responsibilities to make it a bit easier to maintain and adjust in the future.